### PR TITLE
Set default MTU of containers to 1400

### DIFF
--- a/Docker_Project/docker-compose.yml
+++ b/Docker_Project/docker-compose.yml
@@ -110,3 +110,9 @@ services:
       - ./anonymisation_internal/anonymisation_api/anonymise/trained_model:/app/training/trained_model
       - ./anonymisation_internal/anonymisation_api/anonymise/logs:/app/logs
       - ./anonymisation_internal/anonymisation_api/anonymise/models:/models
+
+networks:
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: 1400


### PR DESCRIPTION
Allows running on networks with MTU 1450, e.g. VXLAN isolated.